### PR TITLE
Add support for docker-compose up

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,10 @@ Get the list of all your devices
  resingo devices
  ```
 
+Build and start services using docker-compose.yml in your resinOS
+ ```bash
+resingo  up --host http://resin.local /path/to/docker-compose.yml
+ ```
 
 # Author
 

--- a/cmd/resingo/main.go
+++ b/cmd/resingo/main.go
@@ -58,6 +58,25 @@ func main() {
 			},
 		},
 		{
+			Name:   "up",
+			Usage:  "uses docker-compose.yml to start your services",
+			Action: compose,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "projectName",
+					Usage: "application name",
+				},
+				cli.StringFlag{
+					Name:  "host",
+					Usage: "url to the device",
+				},
+				cli.StringFlag{
+					Name:  "ip",
+					Usage: "url to the device",
+				},
+			},
+		},
+		{
 			Name:   "devices",
 			Usage:  "list all devices",
 			Action: devices,
@@ -148,4 +167,14 @@ func getCOntext() (*resingo.Context, error) {
 		Client: &http.Client{},
 		Config: &resingo.Config{APIKey: tk, ResinEndpoint: ResinURL},
 	}, nil
+}
+
+func compose(ctx *cli.Context) error {
+	cfg := &resingo.Compose{
+		Projectname:  ctx.String("projectName"),
+		Host:         ctx.String("host"),
+		ComposeFiles: ctx.Args(),
+		DeviceIP:     ctx.String("ip"),
+	}
+	return resingo.Up(cfg)
 }

--- a/compose.go
+++ b/compose.go
@@ -1,0 +1,73 @@
+package resingo
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/docker/libcompose/docker"
+	"github.com/docker/libcompose/docker/client"
+	"github.com/docker/libcompose/docker/ctx"
+	"github.com/docker/libcompose/project"
+	"github.com/docker/libcompose/project/options"
+)
+
+const daemonPort = 2375
+
+//Compose is the configuration struct for a dockercompose based project.
+type Compose struct {
+	Projectname   string
+	ComposeFiles  []string
+	Host          string
+	DeviceIP      string
+	ClientOptions *client.Options
+}
+
+//Up does a docker-compose like up. It realies on the Compose struct to achieve
+//this.
+//
+// This works in resin-os only.
+func Up(c *Compose) error {
+	co := client.Options{}
+	if c.ClientOptions != nil {
+		co = *c.ClientOptions
+	} else {
+		u, err := url.Parse(c.Host)
+		if err != nil {
+			if c.DeviceIP != "" {
+				co.Host = fmt.Sprintf("http://%s:%d", c.DeviceIP, daemonPort)
+			}
+			return err
+		}
+		s := strings.Split(u.Host, ":")
+		if len(s) == 1 {
+			co.Host = fmt.Sprintf("%s:%d", c.Host, daemonPort)
+		} else {
+			co.Host = c.Host
+		}
+	}
+	dc, err := client.NewDefaultFactory(co)
+	if err != nil {
+		return err
+	}
+	projectCtx := project.Context{
+		ComposeFiles: c.ComposeFiles,
+		ProjectName:  c.Projectname,
+	}
+	context := &ctx.Context{Context: projectCtx, ClientFactory: dc}
+	return up(context)
+
+}
+
+func up(ctx *ctx.Context) error {
+	project, err := docker.NewProject(ctx, nil)
+	if err != nil {
+		return err
+	}
+	o := options.Create{
+		ForceRecreate: true,
+		ForceBuild:    true,
+	}
+	return project.Up(context.Background(), options.Up{Create: o})
+}


### PR DESCRIPTION
This adds function Up, which implmements the docker-compose up command.
This allows use of docker-compose.yml to define services that will run
on resinOS.

This command is resinOS specific, as It talks directly to the docker
daemon running on the host.

Example usage is,
```go
cfg := &resingo.Compose{
		Projectname:  "Name fof your project",
		Host:         "The url to the device",
		ComposeFiles: []string{"docker-compose.yml},
	}
 resingo.Up(cfg)
```